### PR TITLE
Use date format as defined in _config.yml

### DIFF
--- a/layout/_partial/archive-post.ejs
+++ b/layout/_partial/archive-post.ejs
@@ -1,7 +1,7 @@
 <article class="archive-article archive-type-<%= post.layout %>">
   <div class="archive-article-inner">
     <header class="archive-article-header">
-      <%- partial('post/date', {class_name: 'archive-article-date', date_format: 'YYYY-MM-DD'}) %>
+      <%- partial('post/date', {class_name: 'archive-article-date', date_format: site.date_format}) %>
       <%- partial('post/title', {class_name: 'archive-article-title'}) %>
     </header>
   </div>


### PR DESCRIPTION
Noticed that archive-post.ejs was using fixed date format instead of the site defined format. 