### PR TITLE
fixSearchProblemFirefox

### DIFF
--- a/source/js/insight.js
+++ b/source/js/insight.js
@@ -217,7 +217,7 @@
     });
 
 
-    $(document).on('click focus', '.search-form-submit', function () {
+    $(document).on('click focus', '.search-form-submit', function (event) {
         event.preventDefault();
         $main.addClass('show');
         $main.find('.ins-search-input').focus();


### PR DESCRIPTION
add 'event' as a parameter to the handlers.
#112 
> WebKit follows IE's old behavior of using a global symbol for "event", but Firefox doesn't. When using jQuery, that library normalizes the behavior and ensures that your event handlers are passed the event parameter.
from  https://stackoverflow.com/questions/20522887/referenceerror-event-is-not-defined-error-in-firefox