### PR TITLE
修正百度统计和腾讯统计代码错误

### DIFF
--- a/layout/_partial/baidu-analytics.ejs
+++ b/layout/_partial/baidu-analytics.ejs
@@ -3,7 +3,7 @@
     var _hmt = _hmt || [];
     (function() {
       var hm = document.createElement("script");
-      hm.src = "//hm.baidu.com/hm.js?{{ theme.baidu_analytics }}";
+      hm.src = "//hm.baidu.com/hm.js?<%= theme.baidu_analytics %>";
       var s = document.getElementsByTagName("script")[0];
       s.parentNode.insertBefore(hm, s);
     })();

--- a/layout/_partial/tencent-analytics.ejs
+++ b/layout/_partial/tencent-analytics.ejs
@@ -3,7 +3,7 @@
 	<script type="text/javascript">
     (function() {
       var hm = document.createElement("script");
-      hm.src = "//tajs.qq.com/stats?sId={{ theme.tencent_analytics }}";
+      hm.src = "//tajs.qq.com/stats?sId=<%= theme.tencent_analytics %>";
       var s = document.getElementsByTagName("script")[0];
       s.parentNode.insertBefore(hm, s);
     })();


### PR DESCRIPTION
baidu-analytics和tencent-analytics里，按ejs语法，变量应使用`<%= %>`括起来，而不是`{{ }}`。