### PR TITLE
增加博客编辑功能

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -169,3 +169,8 @@ donate:
 # post copyright
 copyright:
     enable: true
+
+# post edit url, modify your post online for convenience
+# If you put your blog on GitHub, it should look like:
+# https://github.com/username/blog/edit/master/source/_posts/
+post_edit_url: 

--- a/languages/de.yml
+++ b/languages/de.yml
@@ -9,6 +9,7 @@ tweets: Tweets
 prev: zurück
 next: weiter
 comment: Kommentare
+edit: Bearbeiten
 archive_a: Archiv
 archive_b: "Archive: %s"
 page: Seite %d

--- a/languages/default.yml
+++ b/languages/default.yml
@@ -9,6 +9,7 @@ tweets: Tweets
 prev: Prev
 next: Next
 comment: Comments
+edit: Edit
 archive_a: Archives
 archive_b: "Archives: %s"
 page: Page %d

--- a/languages/en.yml
+++ b/languages/en.yml
@@ -9,6 +9,7 @@ tweets: Tweets
 prev: Prev
 next: Next
 comment: Comments
+edit: Edit
 archive_a: Archives
 archive_b: "Archives: %s"
 page: Page %d

--- a/languages/es.yml
+++ b/languages/es.yml
@@ -6,6 +6,7 @@ tweets: Tweets
 prev: Previo
 next: Siguiente
 comment: Comentarios
+edit: Editar
 archive_a: Archivos
 archive_b: "Archivos: %s"
 page: Página %d

--- a/languages/fr.yml
+++ b/languages/fr.yml
@@ -9,6 +9,7 @@ tweets: Tweets
 prev: Préc.
 next: Suiv.
 comment: Commentaires
+edit: Modifier
 archive_a: Archives
 archive_b: "Archives: %s"
 page: Page %d

--- a/languages/nl.yml
+++ b/languages/nl.yml
@@ -7,6 +7,7 @@ tweets: Tweets
 prev: Vorige
 next: Volgende
 comment: Commentaren
+edit: Bewerk
 archive_a: Archieven
 archive_b: "Archieven: %s"
 page: Pagina %d

--- a/languages/no.yml
+++ b/languages/no.yml
@@ -6,6 +6,7 @@ tweets: Tweets
 prev: Forrige
 next: Neste
 comment: Kommentarer
+edit: Redigere
 archive_a: Arkiv
 archive_b: "Arkiv: %s"
 page: Side %d

--- a/languages/pt.yml
+++ b/languages/pt.yml
@@ -6,6 +6,7 @@ tweets: Tweets
 prev: Anterior
 next: Próximo
 comment: Comentários
+edit: Editar
 archive_a: Arquivos
 archive_b: "Arquivos: %s"
 page: Página %d

--- a/languages/ru.yml
+++ b/languages/ru.yml
@@ -6,6 +6,7 @@ tweets: Твиты
 prev: Назад
 next: Вперед
 comment: Комментарии
+edit: Редактировать
 archive_a: Архив
 archive_b: "Архив: %s"
 page: Страница %d

--- a/languages/zh-CN.yml
+++ b/languages/zh-CN.yml
@@ -9,6 +9,7 @@ tweets: 推文
 prev: 上一页
 next: 下一页
 comment: 留言
+edit: 编辑
 archive_a: 归档
 archive_b: 归档：%s
 page: 第 %d 页

--- a/languages/zh-TW.yml
+++ b/languages/zh-TW.yml
@@ -9,6 +9,7 @@ tweets: 推文
 prev: 上一頁
 next: 下一頁
 comment: 留言
+edit: 編輯
 archive_a: 彙整
 archive_b: 彙整：%s
 page: 第 %d 頁

--- a/layout/_partial/article.ejs
+++ b/layout/_partial/article.ejs
@@ -10,6 +10,7 @@
       <%- partial('post/date', {class_name: 'article-date', date_format: null}) %>
       <%- partial('post/category') %>
       <%- partial('post/busuanzi-analytics',{index: index, class_name: 'article-views'}) %>
+      <%- partial('post/edit', {index: index, class_name: 'article-edit'}) %>
     </div>
     <div class="article-entry" itemprop="articleBody">
       <% if (theme.post_excerpt && index){ %>

--- a/layout/_partial/post/edit.ejs
+++ b/layout/_partial/post/edit.ejs
@@ -1,0 +1,6 @@
+<% if (!index && is_post() && theme.post_edit_url){ %>
+	<a class="<%= class_name %>" target="_blank" rel="noopener" href="<%= theme.post_edit_url %><%= page.source.slice(7) %>">
+	<span id="edit"><%= __('edit') %></span>
+	</span>
+	</a>
+<% } %>

--- a/source/css/_partial/article.styl
+++ b/source/css/_partial/article.styl
@@ -89,9 +89,24 @@
 .article-views:hover
   color: color-theme
 
+.article-edit
+  @extend $block-caption
+  text-align: center
+  font-weight: normal
+
+.article-edit:before
+  font-family: "FontAwesome";
+  content: "\f044";
+  @media mq-mobile
+    display: none
+
+.article-edit:hover
+  color: color-theme
+
 .article-date,
 .article-category-link,
 .article-views,
+.article-edit
 .archive-year,
 .archive-tag,
 .archive-category,


### PR DESCRIPTION
增加了博客在线编辑功能，也就是一个跳转到GitHub的的链接。这样，如果设置了TravisCI，即可在线修改博客。

效果预览：

![b4](https://user-images.githubusercontent.com/9983385/49737662-63a1b180-fcc8-11e8-9084-260b938d1b5f.gif)

NexT主题也有这个功能，感觉挺不错的。
