### PR TITLE
行内代码折行，更换MathJax CDN，公式过长加滚动条 Fix#95

### DIFF
--- a/layout/_partial/post/mathjax.ejs
+++ b/layout/_partial/post/mathjax.ejs
@@ -26,5 +26,5 @@
     });
 </script>
 
-<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>

--- a/source/css/_partial/highlight.styl
+++ b/source/css/_partial/highlight.styl
@@ -130,6 +130,7 @@ figure.highlight::-webkit-scrollbar-track { /*滚动条里面轨道*/
   pre, code
     font-family: font-mono
   code
+    white-space: normal
     background: rgba(208,211,248,0.2)
     color: color-default
     padding: 0 0.3em

--- a/source/css/style.styl
+++ b/source/css/style.styl
@@ -36,6 +36,10 @@ body
   color: #fff
 }
 
+.MathJax_Display
+  overflow: auto
+  padding: 1em 0
+
 .article-entry h2, .article-entry h3, .article-entry h4, .article-entry h5, .article-entry h6
   color: color-theme
 


### PR DESCRIPTION
行内代码自动折行：

![](https://s1.ax1x.com/2018/12/11/FYPngS.png)

原Mathjax CDN已guoshi过时，按官方的建议更换为https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js

公式过长时，添加滚动条：

![](https://s1.ax1x.com/2018/12/11/FYP3En.gif)

