### PR TITLE
fix bug: Font Awesome icons can not be shown. #92

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -56,7 +56,7 @@
   <% } %>
   <link href="https://fonts.googleapis.com/css?family=Open+Sans|Montserrat:700" rel="stylesheet" type="text/css">
   <link href="https://fonts.googleapis.com/css?family=Roboto:400,300,300italic,400italic" rel="stylesheet" type="text/css">
-  <link href="//cdn.bootcss.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet">
+  <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet">
   <style type="text/css">
     @font-face{font-family:futura-pt; src:url("css/fonts/FuturaPTBold.otf") format("woff");font-weight:500;font-style:normal;}
     @font-face{font-family:futura-pt-light; src:url("css/fonts/FuturaPTBook.otf") format("woff");font-weight:lighter;font-style:normal;}


### PR DESCRIPTION
Hi iTimeTraveler,
Thanks for your good hexo theme (hiker).
I found out Font Awesome icons can not be shown by IE / Firefox. (Chrome OK) #92 
I just googled it, got the solution and fix it by changing site from [cdn.bootcss.com](url) to [netdna.bootstrapcdn.com](url).

Hope can help the project.
Sincerely,
Wayne