### PR TITLE
modified: line61-63 css relative path

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -58,9 +58,9 @@
   <link href="https://fonts.googleapis.com/css?family=Roboto:400,300,300italic,400italic" rel="stylesheet" type="text/css">
   <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet">
   <style type="text/css">
-    @font-face{font-family:futura-pt; src:url("css/fonts/FuturaPTBold.otf") format("woff");font-weight:500;font-style:normal;}
-    @font-face{font-family:futura-pt-light; src:url("css/fonts/FuturaPTBook.otf") format("woff");font-weight:lighter;font-style:normal;}
-    @font-face{font-family:futura-pt-italic; src:url("css/fonts/FuturaPTBookOblique.otf") format("woff");font-weight:400;font-style:italic;}
+    @font-face{font-family:futura-pt; src:url("<%- config.root %>css/fonts/FuturaPTBold.otf") format("woff");font-weight:500;font-style:normal;}
+    @font-face{font-family:futura-pt-light; src:url("<%- config.root %>css/fonts/FuturaPTBook.otf") format("woff");font-weight:lighter;font-style:normal;}
+    @font-face{font-family:futura-pt-italic; src:url("<%- config.root %>css/fonts/FuturaPTBookOblique.otf") format("woff");font-weight:400;font-style:italic;}
 }
 
   </style>


### PR DESCRIPTION
之前在如果在博客内点击下一页(非第一页)，博客主页标题的字体(就是背景大图中间的那些字)会变得没有样式，并且报错404，“....../page/2/css/fonts/FuturaPTBold.otf”404找不到。 所以就修改了一下相对路径，补充了跟目录<%- config.root %>试了一下问题解决了。